### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Commercial_License.md
+++ b/Commercial_License.md
@@ -1,4 +1,4 @@
-#summary Commercial License
+# summary Commercial License
 
 [iDoubs](http://code.google.com/p/idoubs/) is a free software licensed under the [GNU GPLv3](http://www.gnu.org/licenses/gpl.html) license terms. As far as the commercial product using [iDoubs](http://code.google.com/p/idoubs/) or [doubango](http://doubango.org) isn't a **closed-source** software and is compatible with [GNU GPL](http://www.gnu.org/licenses/gpl.html) terms, there is no license violation. However, if your commercial product is a **closed-source** software and you want to keep it closed, then you should get a non-GPL license. <br /><br />
 We can provide a non-GPL version of all components used in both [iDoubs](http://code.google.com/p/idoubs/) and [doubango](http://doubango.org) except for [x264](http://www.videolan.org/developers/x264.html) library. <br />


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
